### PR TITLE
[Feat/#15, #19] 메인 뷰 UI 장바구니, 최종금액 추가 및 제약 조건 재설정

### DIFF
--- a/KioskProject/Presentation/Sources/Component/BorderStyle.swift
+++ b/KioskProject/Presentation/Sources/Component/BorderStyle.swift
@@ -1,0 +1,14 @@
+//
+//  BorderStyle.swift
+//  KioskProject
+//
+//  Created by 권순욱 on 4/8/25.
+//
+
+import UIKit
+
+struct BorderStyle {
+    static let width: CGFloat = 1
+    static let color: CGColor = UIColor.systemGray4.cgColor
+    static let cornerRadius: CGFloat = 8
+}

--- a/KioskProject/Presentation/Sources/Component/CartTableViewCell.swift
+++ b/KioskProject/Presentation/Sources/Component/CartTableViewCell.swift
@@ -1,0 +1,107 @@
+//
+//  CartTableViewCell.swift
+//  KioskProject
+//
+//  Created by 권순욱 on 4/8/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class CartTableViewCell: UITableViewCell {
+    static let reuseIdentifier = "CartTableViewCell"
+    
+    var productName: String = ""
+    var orderCount: Int = 0
+    var orderAmounts: Int = 0
+    
+    private lazy var productNameLabel = UILabel().then {
+        $0.text = productName
+        $0.font = .systemFont(ofSize: 14)
+    }
+    
+    private lazy var orderCountLabel = UILabel().then {
+        $0.text = "\(orderCount)"
+        $0.font = .systemFont(ofSize: 14)
+    }
+    
+    private lazy var orderamountsLabel = UILabel().then {
+        $0.text = "\(wonFormatter(orderAmounts))"
+        $0.font = .systemFont(ofSize: 14)
+    }
+    
+    let incrementButton = UIButton().then {
+        $0.setTitle("+", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+    }
+    
+    let decrementButton = UIButton().then {
+        $0.setTitle("-", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+    func setupUI(productName: String, orderCount: Int, orderAmounts: Int) {
+        self.productName = productName
+        self.orderCount = orderCount
+        self.orderAmounts = orderAmounts
+        
+        [productNameLabel, orderCountLabel, orderamountsLabel, incrementButton, decrementButton]
+            .forEach { addSubview($0) }
+        
+        setConstraints()
+    }
+    
+    private func setConstraints() {
+        productNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.leading.equalToSuperview().offset(8)
+            $0.bottom.equalToSuperview().offset(-4)
+        }
+        
+        orderCountLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-4)
+        }
+        
+        orderamountsLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.trailing.equalToSuperview().offset(-8)
+            $0.bottom.equalToSuperview().offset(-4)
+        }
+        
+        decrementButton.snp.makeConstraints {
+            $0.trailing.equalTo(orderCountLabel.snp.leading).offset(-8)
+            $0.centerY.equalTo(orderCountLabel.snp.centerY)
+        }
+        
+        incrementButton.snp.makeConstraints {
+            $0.leading.equalTo(orderCountLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(orderCountLabel.snp.centerY)
+        }
+    }
+
+    private func wonFormatter(_ number: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: NSNumber(value: number)) ?? ""
+    }
+}

--- a/KioskProject/Presentation/Sources/Component/CartView.swift
+++ b/KioskProject/Presentation/Sources/Component/CartView.swift
@@ -6,41 +6,46 @@
 //
 
 import UIKit
+import SnapKit
 import Then
 
-class CartView: UIView {
+class CartView: UIStackView {
+    var orderCount: Int
+    
     private let titleLabel = UILabel().then {
-        $0.text = "장바구니"
+        $0.text = " 장바구니"
         $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
-    private let tableView = CartTableView()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        addSubview(titleLabel)
-        addSubview(tableView)
-        
-        setConstraints()
+    private lazy var orderCountLabel = UILabel().then {
+        $0.text = "총 \(orderCount)개 "
+        $0.font = .systemFont(ofSize: 16)
     }
     
-    required init?(coder: NSCoder) {
+    private let titleStackView = UIStackView()
+    
+    let tableView = CartTableView()
+    
+    init(orderCount: Int = 3) {
+        self.orderCount = orderCount
+        super.init(frame: .zero)
+        
+        [titleLabel, orderCountLabel].forEach {
+            titleStackView.addArrangedSubview($0)
+        }
+        titleStackView.axis = .horizontal
+        titleStackView.distribution = .equalSpacing
+        titleStackView.alignment = .bottom
+        
+        [titleStackView, tableView].forEach {
+            addArrangedSubview($0)
+        }
+        axis = .vertical
+        spacing = 4
+    }
+    
+    required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setConstraints() {
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(4)
-            $0.trailing.equalToSuperview()
-        }
-        
-        tableView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
-            $0.leading.equalToSuperview()
-            $0.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview()
-        }
     }
 }
 

--- a/KioskProject/Presentation/Sources/Component/CartView.swift
+++ b/KioskProject/Presentation/Sources/Component/CartView.swift
@@ -10,42 +10,65 @@ import SnapKit
 import Then
 
 class CartView: UIStackView {
-    var orderCount: Int
-    
-    let tableView = CartTableView()
-    
     private let titleLabel = UILabel().then {
         $0.text = " 장바구니"
         $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
     
-    private let titleStackView = UIStackView()
+    private let titleStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.alignment = .bottom
+    }
+    
+    var orderCount: Int
     
     private lazy var orderCountLabel = UILabel().then {
-        $0.text = "총 \(orderCount)개 "
+        $0.text = "총 \(orderCount)개"
         $0.font = .systemFont(ofSize: 16)
     }
+    
+    let cartTableView = CartTableView()
+    
+    var tableViewHeightConstraint: Constraint?
     
     init(orderCount: Int = 3) {
         self.orderCount = orderCount
         super.init(frame: .zero)
         
-        [titleLabel, orderCountLabel].forEach {
-            titleStackView.addArrangedSubview($0)
-        }
-        titleStackView.axis = .horizontal
-        titleStackView.distribution = .equalSpacing
-        titleStackView.alignment = .bottom
+        self.axis = .vertical
+        self.spacing = 4
         
-        [titleStackView, tableView].forEach {
-            addArrangedSubview($0)
-        }
-        axis = .vertical
-        spacing = 4
+        configureView()
+        setConstraints()
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureView() {
+        [titleStackView, cartTableView].forEach {
+            self.addArrangedSubview($0)
+        }
+        
+        [titleLabel, orderCountLabel].forEach {
+            titleStackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func setConstraints() {
+        cartTableView.snp.makeConstraints {
+            tableViewHeightConstraint = $0.height.equalTo(0).constraint
+        }
+    }
+    
+    func updateTableViewHeight() {
+        cartTableView.layoutIfNeeded()
+        
+        let contentHeight = cartTableView.contentSize.height
+        
+        tableViewHeightConstraint?.update(offset: contentHeight)
     }
 }
 
@@ -58,6 +81,8 @@ class CartTableView: UITableView {
         layer.borderWidth = BorderStyle.width
         layer.borderColor = BorderStyle.color
         layer.cornerRadius = BorderStyle.cornerRadius
+        
+        self.isScrollEnabled = false
     }
     
     required init?(coder: NSCoder) {

--- a/KioskProject/Presentation/Sources/Component/CartView.swift
+++ b/KioskProject/Presentation/Sources/Component/CartView.swift
@@ -1,0 +1,61 @@
+//
+//  CartView.swift
+//  KioskProject
+//
+//  Created by 권순욱 on 4/8/25.
+//
+
+import UIKit
+import Then
+
+class CartView: UIView {
+    private let titleLabel = UILabel().then {
+        $0.text = "장바구니"
+        $0.font = .systemFont(ofSize: 20, weight: .bold)
+    }
+    private let tableView = CartTableView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(titleLabel)
+        addSubview(tableView)
+        
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(4)
+            $0.trailing.equalToSuperview()
+        }
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}
+
+class CartTableView: UITableView {
+    init() {
+        super.init(frame: .zero, style: .grouped)
+        
+        backgroundColor = .white
+        
+        layer.borderWidth = BorderStyle.width
+        layer.borderColor = BorderStyle.color
+        layer.cornerRadius = BorderStyle.cornerRadius
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/KioskProject/Presentation/Sources/Component/CartView.swift
+++ b/KioskProject/Presentation/Sources/Component/CartView.swift
@@ -12,19 +12,19 @@ import Then
 class CartView: UIStackView {
     var orderCount: Int
     
+    let tableView = CartTableView()
+    
     private let titleLabel = UILabel().then {
         $0.text = " 장바구니"
         $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
     
+    private let titleStackView = UIStackView()
+    
     private lazy var orderCountLabel = UILabel().then {
         $0.text = "총 \(orderCount)개 "
         $0.font = .systemFont(ofSize: 16)
     }
-    
-    private let titleStackView = UIStackView()
-    
-    let tableView = CartTableView()
     
     init(orderCount: Int = 3) {
         self.orderCount = orderCount

--- a/KioskProject/Presentation/Sources/Component/OrderButtonView.swift
+++ b/KioskProject/Presentation/Sources/Component/OrderButtonView.swift
@@ -15,12 +15,13 @@ class OrderButtonView: UIStackView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        [confirmButton, cancelButton].forEach {
+        [cancelButton, confirmButton].forEach {
             self.addArrangedSubview($0)
         }
         
-        self.axis = .vertical
-        self.spacing = 8
+        self.axis = .horizontal
+        self.spacing = 16
+        self.distribution = .fillEqually
         self.isLayoutMarginsRelativeArrangement = true
         self.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 16)
     }

--- a/KioskProject/Presentation/Sources/Component/PaymentView.swift
+++ b/KioskProject/Presentation/Sources/Component/PaymentView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 import Then
 
 class PaymentView: UIView {
@@ -13,7 +14,7 @@ class PaymentView: UIView {
         $0.text = "최종금액"
         $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
-    private let paymentStackView = PaymentStackView(totalAmounts: 0, deliveryFee: 0)
+    private let paymentStackView = PaymentStackView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -45,10 +46,43 @@ class PaymentView: UIView {
 }
 
 class PaymentStackView: UIStackView {
-    var totalAmounts: Int = 0
-    var deliveryFee: Int = 0
+    private let totalAmountTitle = UILabel().then {
+        $0.text = "상품 금액"
+        $0.font = .systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .gray
+    }
     
-    init(totalAmounts: Int, deliveryFee: Int) {
+    private let deliveryFeeTitle = UILabel().then {
+        $0.text = "배송비"
+        $0.font = .systemFont(ofSize: 16, weight: .semibold)
+        $0.textColor = .gray
+    }
+    
+    private lazy var totalAmountLabel = UILabel().then {
+        $0.text = "\(wonFormatter(totalAmounts))"
+        $0.font = .systemFont(ofSize: 15, weight: .semibold)
+        $0.textColor = .darkGray
+    }
+    
+    private lazy var deliveryFeeLabel = UILabel().then {
+        $0.text = "\(wonFormatter(deliveryFee))"
+        $0.font = .systemFont(ofSize: 15, weight: .semibold)
+        $0.textColor = .darkGray
+    }
+    
+    private lazy var finalPriceLabel = UILabel().then {
+        $0.text = "\(wonFormatter(totalAmounts + deliveryFee))"
+        $0.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.textColor = .black
+    }
+    
+    private let totalAmountView = UIStackView()
+    private let deliveryFeeView = UIStackView()
+    
+    var totalAmounts: Int
+    var deliveryFee: Int
+    
+    init(totalAmounts: Int = 600000, deliveryFee: Int = 2500) {
         self.totalAmounts = totalAmounts
         self.deliveryFee = deliveryFee
         
@@ -58,12 +92,56 @@ class PaymentStackView: UIStackView {
         layer.borderColor = BorderStyle.color
         layer.cornerRadius = BorderStyle.cornerRadius
         
-        snp.makeConstraints {
-            $0.height.equalTo(120)
+        [totalAmountTitle, totalAmountLabel].forEach {
+            totalAmountView.addArrangedSubview($0)
         }
+        totalAmountView.axis = .horizontal
+        totalAmountView.distribution = .equalSpacing
+        
+        [deliveryFeeTitle, deliveryFeeLabel].forEach {
+            deliveryFeeView.addArrangedSubview($0)
+        }
+        deliveryFeeView.axis = .horizontal
+        deliveryFeeView.distribution = .equalSpacing
+        
+        [totalAmountView, deliveryFeeView, finalPriceLabel].forEach {
+            addSubview($0)
+        }
+        
+        setConstraints()
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setConstraints() {
+        snp.makeConstraints {
+            $0.height.equalTo(120)
+        }
+        
+        totalAmountView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+        
+        deliveryFeeView.snp.makeConstraints {
+            $0.top.equalTo(totalAmountView.snp.bottom).offset(8)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+        
+        finalPriceLabel.snp.makeConstraints {
+            $0.top.equalTo(deliveryFeeView.snp.bottom).offset(16)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+    }
+    
+    private func wonFormatter(_ number: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: NSNumber(value: number)) ?? ""
     }
 }

--- a/KioskProject/Presentation/Sources/Component/PaymentView.swift
+++ b/KioskProject/Presentation/Sources/Component/PaymentView.swift
@@ -46,6 +46,9 @@ class PaymentView: UIView {
 }
 
 class PaymentStackView: UIStackView {
+    var totalAmounts: Int
+    var deliveryFee: Int
+    
     private let totalAmountTitle = UILabel().then {
         $0.text = "상품 금액"
         $0.font = .systemFont(ofSize: 16, weight: .semibold)
@@ -57,6 +60,9 @@ class PaymentStackView: UIStackView {
         $0.font = .systemFont(ofSize: 16, weight: .semibold)
         $0.textColor = .gray
     }
+    
+    private let totalAmountView = UIStackView()
+    private let deliveryFeeView = UIStackView()
     
     private lazy var totalAmountLabel = UILabel().then {
         $0.text = "\(wonFormatter(totalAmounts))"
@@ -75,12 +81,6 @@ class PaymentStackView: UIStackView {
         $0.font = .systemFont(ofSize: 18, weight: .semibold)
         $0.textColor = .black
     }
-    
-    private let totalAmountView = UIStackView()
-    private let deliveryFeeView = UIStackView()
-    
-    var totalAmounts: Int
-    var deliveryFee: Int
     
     init(totalAmounts: Int = 600000, deliveryFee: Int = 2500) {
         self.totalAmounts = totalAmounts

--- a/KioskProject/Presentation/Sources/Component/PaymentView.swift
+++ b/KioskProject/Presentation/Sources/Component/PaymentView.swift
@@ -1,0 +1,69 @@
+//
+//  PaymentView.swift
+//  KioskProject
+//
+//  Created by 권순욱 on 4/8/25.
+//
+
+import UIKit
+import Then
+
+class PaymentView: UIView {
+    private let titleLabel = UILabel().then {
+        $0.text = "최종금액"
+        $0.font = .systemFont(ofSize: 20, weight: .bold)
+    }
+    private let paymentStackView = PaymentStackView(totalAmounts: 0, deliveryFee: 0)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(titleLabel)
+        addSubview(paymentStackView)
+        
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(4)
+            $0.trailing.equalToSuperview()
+        }
+        
+        paymentStackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}
+
+class PaymentStackView: UIStackView {
+    var totalAmounts: Int = 0
+    var deliveryFee: Int = 0
+    
+    init(totalAmounts: Int, deliveryFee: Int) {
+        self.totalAmounts = totalAmounts
+        self.deliveryFee = deliveryFee
+        
+        super.init(frame: .zero)
+        
+        layer.borderWidth = BorderStyle.width
+        layer.borderColor = BorderStyle.color
+        layer.cornerRadius = BorderStyle.cornerRadius
+        
+        snp.makeConstraints {
+            $0.height.equalTo(120)
+        }
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/KioskProject/Presentation/Sources/Component/TableViewCell/CartTableViewCell.swift
+++ b/KioskProject/Presentation/Sources/Component/TableViewCell/CartTableViewCell.swift
@@ -71,7 +71,7 @@ class CartTableViewCell: UITableViewCell {
     private func setConstraints() {
         productNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(4)
-            $0.leading.equalToSuperview().offset(8)
+            $0.leading.equalToSuperview().offset(16)
             $0.bottom.equalToSuperview().offset(-4)
         }
         
@@ -83,7 +83,7 @@ class CartTableViewCell: UITableViewCell {
         
         orderamountsLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(4)
-            $0.trailing.equalToSuperview().offset(-8)
+            $0.trailing.equalToSuperview().offset(-16)
             $0.bottom.equalToSuperview().offset(-4)
         }
         

--- a/KioskProject/Presentation/Sources/Component/TableViewCell/TotalAmountCell.swift
+++ b/KioskProject/Presentation/Sources/Component/TableViewCell/TotalAmountCell.swift
@@ -1,0 +1,72 @@
+//
+//  CartTableViewCell 2.swift
+//  KioskProject
+//
+//  Created by 권순욱 on 4/9/25.
+//
+
+
+import UIKit
+import SnapKit
+import Then
+
+class TotalAmountCell: UITableViewCell {
+    static let reuseIdentifier = "TotalAmountCell"
+    
+    var orderAmounts: Int = 0
+    
+    private lazy var titleLabel = UILabel().then {
+        $0.text = "주문금액"
+        $0.font = .systemFont(ofSize: 14, weight: .bold)
+    }
+    
+    private lazy var orderamountsLabel = UILabel().then {
+        $0.text = "\(wonFormatter(orderAmounts))"
+        $0.font = .systemFont(ofSize: 14, weight: .bold)
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+    func setupUI(orderAmounts: Int) {
+    
+        self.orderAmounts = orderAmounts
+        
+        [titleLabel, orderamountsLabel]
+            .forEach { addSubview($0) }
+        
+        setConstraints()
+    }
+    
+    private func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.leading.equalToSuperview().offset(16)
+            $0.bottom.equalToSuperview().offset(-4)
+        }
+        
+        orderamountsLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.trailing.equalToSuperview().offset(-16)
+            $0.bottom.equalToSuperview().offset(-4)
+        }
+    }
+
+    private func wonFormatter(_ number: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: NSNumber(value: number)) ?? ""
+    }
+}

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -66,7 +66,11 @@ final class MainView: UIView {
         let spacing: CGFloat = 16
         let totalSpacing = spacing * 3
         let width = (UIScreen.main.bounds.width - spacing * 3) / 2
-        let height = (width * 2) + totalSpacing
+        let height = width * 2 + totalSpacing
+        // productNameLabel height: 25
+        // priceLabel hegith: 22
+        // label spacing: 8
+//        let height = (width * 2) + totalSpacing + (47 * 2) + (8 * 3 * 2)
         
         mainScrollView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -36,7 +36,7 @@ final class MainView: UIView {
     let paymentView = PaymentView()
     
     let orderButtonView = OrderButtonView()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -66,7 +66,8 @@ final class MainView: UIView {
         let spacing: CGFloat = 16
         let width = (UIScreen.main.bounds.width - spacing * 3) / 2
         // 여기서 item의 높이를 지정해주고 있는데 현재는 임의로 가로 + 60으로 지정해주는 중
-        let height = width + 70
+        let height = (width * 0.6) + 60
+//        let height = (bounds.height - totalSpacing) / 2
         
         mainScrollView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
@@ -94,8 +95,8 @@ final class MainView: UIView {
         productCollectionView.snp.makeConstraints {
             $0.top.equalTo(categoryView.snp.bottom)//.offset(8)
             $0.horizontalEdges.equalToSuperview()
-//            $0.height.equalTo(height * 2 + spacing * 3)
-            $0.height.equalToSuperview().dividedBy(2)
+            $0.height.equalTo(height * 2 + spacing * 3)
+//            $0.height.equalToSuperview().dividedBy(2)
         }
         
         pageControl.snp.makeConstraints {
@@ -107,11 +108,10 @@ final class MainView: UIView {
             $0.top.equalTo(pageControl.snp.bottom).offset(8)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
-            $0.height.equalTo(180)
         }
         
         paymentView.snp.makeConstraints {
-            $0.top.equalTo(cartView.snp.bottom).offset(8)
+            $0.top.equalTo(cartView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
             $0.bottom.equalToSuperview()

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -41,6 +41,7 @@ final class MainView: UIView {
         }
         
         cartView.snp.makeConstraints {
+            // $0.top.equalTo(titleView.snp.bottom).offset(8)
             $0.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
             $0.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
             $0.height.equalTo(180)

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -11,6 +11,8 @@ import SnapKit
 final class MainView: UIView {
     let titleView = TitleView()
     let orderButtonView = OrderButtonView()
+    let cartView = CartView()
+    let paymentView = PaymentView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -20,6 +22,9 @@ final class MainView: UIView {
         [titleView, orderButtonView].forEach {
             addSubview($0)
         }
+        
+        addSubview(cartView)
+        addSubview(paymentView)
         
         setConstraints()
     }
@@ -33,6 +38,19 @@ final class MainView: UIView {
             $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(8)
             $0.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
             $0.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+        }
+        
+        cartView.snp.makeConstraints {
+            $0.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            $0.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            $0.height.equalTo(180)
+        }
+        
+        paymentView.snp.makeConstraints {
+            $0.top.equalTo(cartView.snp.bottom).offset(8)
+            $0.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            $0.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            $0.bottom.equalTo(orderButtonView.snp.top).offset(-14)
         }
         
         orderButtonView.snp.makeConstraints {

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -64,10 +64,9 @@ final class MainView: UIView {
     
     private func setConstraints() {
         let spacing: CGFloat = 16
+        let totalSpacing = spacing * 3
         let width = (UIScreen.main.bounds.width - spacing * 3) / 2
-        // 여기서 item의 높이를 지정해주고 있는데 현재는 임의로 가로 + 60으로 지정해주는 중
-        let height = (width * 0.6) + 60
-//        let height = (bounds.height - totalSpacing) / 2
+        let height = (width * 2) + totalSpacing
         
         mainScrollView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
@@ -93,14 +92,13 @@ final class MainView: UIView {
         }
         
         productCollectionView.snp.makeConstraints {
-            $0.top.equalTo(categoryView.snp.bottom)//.offset(8)
+            $0.top.equalTo(categoryView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(height * 2 + spacing * 3)
-//            $0.height.equalToSuperview().dividedBy(2)
+            $0.height.equalTo(height)
         }
         
         pageControl.snp.makeConstraints {
-            $0.top.equalTo(productCollectionView.snp.bottom)//.offset(8)
+            $0.top.equalTo(productCollectionView.snp.bottom)
             $0.centerX.equalToSuperview()
         }
         

--- a/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
@@ -28,9 +28,7 @@ final class ProductCollectionView: UICollectionView {
             let spacing: CGFloat = 16
             let totalSpacing = spacing * 3
             let width = (bounds.width - totalSpacing) / 2
-            // 여기서 item의 높이를 지정해주고 있는데 현재는 임의로 가로 + 60으로 지정해주는 중
-            let height = (width * 0.6) + 60
-//            let height = (bounds.height - totalSpacing) / 2
+            let height = width
             
             layout.itemSize = CGSize(width: width, height: height)
             layout.minimumLineSpacing = spacing

--- a/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
@@ -30,6 +30,10 @@ final class ProductCollectionView: UICollectionView {
             let width = (bounds.width - totalSpacing) / 2
             let height = width
             
+            // productNameLabel height: 25
+            // priceLabel hegith: 22
+//            let height = width + 47 + (8 * 3)
+            
             layout.itemSize = CGSize(width: width, height: height)
             layout.minimumLineSpacing = spacing
             layout.minimumInteritemSpacing = spacing

--- a/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
@@ -29,8 +29,8 @@ final class ProductCollectionView: UICollectionView {
             let totalSpacing = spacing * 3
             let width = (bounds.width - totalSpacing) / 2
             // 여기서 item의 높이를 지정해주고 있는데 현재는 임의로 가로 + 60으로 지정해주는 중
-//            let height = width + 70
-            let height = (bounds.height - totalSpacing) / 2
+            let height = (width * 0.6) + 60
+//            let height = (bounds.height - totalSpacing) / 2
             
             layout.itemSize = CGSize(width: width, height: height)
             layout.minimumLineSpacing = spacing

--- a/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
@@ -72,7 +72,6 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         productImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalToSuperview().multipliedBy(0.6)
         }
         
         productNameLabel.snp.makeConstraints {
@@ -83,7 +82,7 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         priceLabel.snp.makeConstraints {
             $0.top.equalTo(productNameLabel.snp.bottom).offset(8)
             $0.leading.equalTo(productNameLabel.snp.leading)
-//            $0.bottom.equalToSuperview().offset(-8)
+            $0.bottom.equalToSuperview().offset(-8)
         }
     }
     

--- a/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
@@ -72,6 +72,7 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         productImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
+//            $0.height.equalTo(productImageView.snp.width)
         }
         
         productNameLabel.snp.makeConstraints {

--- a/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionViewCell.swift
@@ -72,7 +72,7 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         productImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalToSuperview().multipliedBy(0.7)
+            $0.height.equalToSuperview().multipliedBy(0.6)
         }
         
         productNameLabel.snp.makeConstraints {

--- a/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
+++ b/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
@@ -15,6 +15,8 @@ final class MainViewController: UIViewController {
     
     private let viewModel: MainViewModel
     
+    private var items = ["1", "2", "3", "4", "1", "2", "3", "4"]
+    
     override func loadView() {
         view = mainView
     }
@@ -24,13 +26,23 @@ final class MainViewController: UIViewController {
         
         mainView.productCollectionView.delegate = self
         mainView.productCollectionView.dataSource = self
+        
+        setTableViewData()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        mainView.cartView.updateTableViewHeight()
+        
+//        mainView.layoutIfNeeded()
+        
     }
     
     init(DIContainer: KioskDIContainerInterface) {
         self.viewModel = DIContainer.makeMainViewModel()
         super.init(nibName: nil, bundle: nil)
         
-        setTableViewData()
     }
     
     required init?(coder: NSCoder) {
@@ -38,13 +50,13 @@ final class MainViewController: UIViewController {
     }
     
     private func setTableViewData() {
-        mainView.cartView.tableView.dataSource = self
-        mainView.cartView.tableView.delegate = self
+        mainView.cartView.cartTableView.dataSource = self
+        mainView.cartView.cartTableView.delegate = self
         
-        mainView.cartView.tableView.register(CartTableViewCell.self, forCellReuseIdentifier: CartTableViewCell.reuseIdentifier)
-        mainView.cartView.tableView.register(TotalAmountCell.self, forCellReuseIdentifier: TotalAmountCell.reuseIdentifier)
+        mainView.cartView.cartTableView.register(CartTableViewCell.self, forCellReuseIdentifier: CartTableViewCell.reuseIdentifier)
+        mainView.cartView.cartTableView.register(TotalAmountCell.self, forCellReuseIdentifier: TotalAmountCell.reuseIdentifier)
         
-        mainView.cartView.tableView.separatorStyle = .none
+        mainView.cartView.cartTableView.separatorStyle = .none
     }
 }
 
@@ -55,7 +67,7 @@ extension MainViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == 0 { // 각 상품별 구매수량 및 금액
-            return 4
+            return items.count
         } else { // 총 금액
             return 1
         }

--- a/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
+++ b/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
@@ -27,9 +27,23 @@ final class MainViewController: UIViewController {
         self.viewModel = DIContainer.makeMainViewModel()
         super.init(nibName: nil, bundle: nil)
         
+        mainView.cartView.tableView.dataSource = self
+        mainView.cartView.tableView.register(CartTableViewCell.self, forCellReuseIdentifier: CartTableViewCell.reuseIdentifier)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension MainViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 4
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: CartTableViewCell.reuseIdentifier, for: indexPath) as! CartTableViewCell
+        cell.setupUI(productName: "iPhone 15", orderCount: 1, orderAmounts: 300000)
+        return cell
     }
 }

--- a/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
+++ b/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
@@ -15,7 +15,7 @@ final class MainViewController: UIViewController {
     
     private let viewModel: MainViewModel
     
-    private var items = ["1", "2", "3", "4", "1", "2", "3", "4"]
+    private var items = [1, 2, 3, 4, 5, 6, 7, 8]
     
     override func loadView() {
         view = mainView
@@ -99,7 +99,7 @@ extension MainViewController: UITableViewDelegate {
         if section == 0 {
             return 8
         } else {
-            return 4
+            return 0
         }
     }
     
@@ -107,7 +107,7 @@ extension MainViewController: UITableViewDelegate {
         if section == 0 {
             return 0
         } else {
-            return 8
+            return 0
         }
     }
 }

--- a/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
+++ b/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
@@ -27,23 +27,72 @@ final class MainViewController: UIViewController {
         self.viewModel = DIContainer.makeMainViewModel()
         super.init(nibName: nil, bundle: nil)
         
-        mainView.cartView.tableView.dataSource = self
-        mainView.cartView.tableView.register(CartTableViewCell.self, forCellReuseIdentifier: CartTableViewCell.reuseIdentifier)
+        setTableViewData()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    private func setTableViewData() {
+        mainView.cartView.tableView.dataSource = self
+        mainView.cartView.tableView.delegate = self
+        
+        mainView.cartView.tableView.register(CartTableViewCell.self, forCellReuseIdentifier: CartTableViewCell.reuseIdentifier)
+        mainView.cartView.tableView.register(TotalAmountCell.self, forCellReuseIdentifier: TotalAmountCell.reuseIdentifier)
+        
+        mainView.cartView.tableView.separatorStyle = .none
+    }
 }
 
 extension MainViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2 // 각 상품별 구매수량 및 금액, 총 금액
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 4
+        if section == 0 { // 각 상품별 구매수량 및 금액
+            return 4
+        } else { // 총 금액
+            return 1
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: CartTableViewCell.reuseIdentifier, for: indexPath) as! CartTableViewCell
-        cell.setupUI(productName: "iPhone 15", orderCount: 1, orderAmounts: 300000)
-        return cell
+        if indexPath.section == 0 {
+            let cell = tableView.dequeueReusableCell(withIdentifier: CartTableViewCell.reuseIdentifier, for: indexPath) as! CartTableViewCell
+            cell.setupUI(productName: "iPhone 15", orderCount: 1, orderAmounts: 300000)
+            return cell
+        } else {
+            let cell = tableView.dequeueReusableCell(withIdentifier: TotalAmountCell.reuseIdentifier, for: indexPath) as! TotalAmountCell
+            cell.setupUI(orderAmounts: 600000)
+            return cell
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return UIView()
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+}
+
+extension MainViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section == 0 {
+            return 8
+        } else {
+            return 4
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == 0 {
+            return 0
+        } else {
+            return 8
+        }
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
장바구니와 최종금액 뷰를 기존 메인 화면 UI에 추가 후 레이아웃 제약조건 재설정
<!---- Resolves: #(Isuue Number) -->

# What is this PR? 🔍
- Issues: https://github.com/Team-TJ-Media/KioskProject/issues/15, https://github.com/Team-TJ-Media/KioskProject/issues/19

## PR 유형 ☑️
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## Changes 📝
상세한 변경 사항을 적어주세요!
- 메인 뷰 화면 중 장바구니, 최종금액 UI 구성
- 기존에 작성된 타이틀, 카테고리, 상품리스트, 주문하기 버튼과 함께 레이아웃 제약조건을 다시 지정
- 추가로 상품 리스트 컬렉션 뷰는 item의 가로, 세로 사이즈가 동일하도록 구성
- 장바구니 테이블 뷰는 스크롤이 불가하며 상품이 추가되고 삭제될 때 cell의 높이에 따라 동적으로 테이블 뷰의 높이가 변경 됨

## ScreenShot 📸
| 기능 | 이전 스크린샷 | 이후 스크린샷 |
|-------|-------|-------|
| **상품 리스트 아이템의 크기 (1:1)** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 29 31](https://github.com/user-attachments/assets/0cee3516-2d2c-4ec3-b735-c668131e200a) |
| **장바구니 테이블 뷰 높이 (상품 8개)** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 29 34](https://github.com/user-attachments/assets/77a70cc3-d11a-431c-923f-557d931e5468) |
| **장바구니 테이블 뷰 동적 높이 (상품 3개)** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 29 51](https://github.com/user-attachments/assets/d393d5c3-bb1d-40fe-a880-846575c8476f) |
| 링크 | [📎]() | [📎]() |

## Test Checklist ✅
- [x] 타이틀, 카테고리, 상품리스트, 장바구니, 최종금액, 주문하기 버튼 View 들의 레이아웃 제약조건이 제대로 잡혀있습니다.
- [x] 상품 리스트의 각각의 아이템은 가로, 세로 1:1 비율로 보이고 있습니다.
- [x] 장바구니 테이블 뷰는 담겨진 상품의 개수에 따라 테이블 뷰의 높이가 동적으로 변하고 있습니다.

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. (커밋 메시지 컨벤션 참고)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
