### PR TITLE
[feat/#18] AlertType 정의 및 UIViewController showAlert 메서드 구현

### DIFF
--- a/KioskProject/Presentation/Sources/View/AlertType.swift
+++ b/KioskProject/Presentation/Sources/View/AlertType.swift
@@ -1,0 +1,36 @@
+//
+//  AlertType.swift
+//  KioskProject
+//
+//  Created by 백래훈 on 4/9/25.
+//
+
+import Foundation
+
+enum AlertType {
+    case emptyCart
+    case confirmCancel
+    case confirmOrder(Int)
+    
+    var title: String {
+        switch self {
+        case .emptyCart:
+            return "주문 실패"
+        case .confirmCancel:
+            return "주문 취소"
+        case .confirmOrder:
+            return "주문 확인"
+        }
+    }
+    
+    var message: String {
+        switch self {
+        case .emptyCart:
+            return "장바구니가 비어있습니다.\n먼저 상품을 장바구니에 담아주세요!"
+        case .confirmCancel:
+            return "장바구니 내역이 삭제됩니다.\n정말 취소하시겠습니까?"
+        case .confirmOrder(let price):
+            return "총 결제 금액은 ₩\(price)입니다. 결제하시겠습니까?"
+        }
+    }
+}

--- a/KioskProject/Presentation/Sources/View/Extension+UIViewController.swift
+++ b/KioskProject/Presentation/Sources/View/Extension+UIViewController.swift
@@ -1,0 +1,22 @@
+//
+//  Extension+UIViewController.swift
+//  KioskProject
+//
+//  Created by 백래훈 on 4/9/25.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showAlert(type: AlertType, confirmHandler: (() -> Void)? = nil) {
+        let alert = UIAlertController(title: type.title, message: type.message, preferredStyle: .alert)
+        
+        let confirm = UIAlertAction(title: "확인", style: .default)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(confirm)
+        alert.addAction(cancel)
+        
+        self.present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자에게 주문 상태에 관련한 Alert 제공
<!---- Resolves: #(Isuue Number) -->

# What is this PR? 🔍
- Issues: https://github.com/Team-TJ-Media/KioskProject/issues/18

## PR 유형 ☑️
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## Changes 📝
상세한 변경 사항을 적어주세요!

- AlertType enum 추가
  - emptyCart: 장바구니가 비어있는 경우
  - confirmCancel: 주문 취소 확인용
  - confirmOrder(Int): 결제 금액을 포함한 주문 확인용

- UIViewController extension에 showAlert 메서드 구현
  - AlertType 기반으로 title, message 구성
  - handler를 통해 버튼 클릭 이벤트 처리 가능

## ScreenShot 📸
| 기능 | 이전 스크린샷 | 이후 스크린샷 |
|-------|-------|-------|
| **주문 실패** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 54 35](https://github.com/user-attachments/assets/002b0c50-18a3-4ae8-b94b-ecdd56806717) |
| **주문 취소** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 54 47](https://github.com/user-attachments/assets/80292881-c9f5-4eaa-a39d-33ad54efd020) |
| **주문 확인** | - | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-10 at 11 55 00](https://github.com/user-attachments/assets/099155f9-8cd8-4c30-b0dc-e76cb56d566e) |
| 링크 | [📎]() | [📎]() |

## Test Checklist ✅
- [x] AlertType case에 따른 Alert title과 message를 상황에 맞게 보여주고 있습니다.

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. (커밋 메시지 컨벤션 참고)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
