### PR TITLE
[Feat/#24] 장바구니 tableView heigth 동적 바인딩 수정 완료

### DIFF
--- a/KioskProject/Presentation/Sources/Utils/Extension/Extension+UIViewController.swift
+++ b/KioskProject/Presentation/Sources/Utils/Extension/Extension+UIViewController.swift
@@ -11,7 +11,9 @@ extension UIViewController {
     func showAlert(type: AlertType, confirmHandler: (() -> Void)? = nil) {
         let alert = UIAlertController(title: type.title, message: type.message, preferredStyle: .alert)
         
-        let confirm = UIAlertAction(title: "확인", style: .default)
+        let confirm = UIAlertAction(title: "확인", style: .default){ _ in
+            confirmHandler?()
+        }
         let cancel = UIAlertAction(title: "취소", style: .cancel)
         
         alert.addAction(confirm)

--- a/KioskProject/Presentation/Sources/View/CartView.swift
+++ b/KioskProject/Presentation/Sources/View/CartView.swift
@@ -37,11 +37,13 @@ class CartView: UIStackView {
         spacing = 4
         configureView()
         setConstraints()
+        setupContentSizeObserver()
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
     //서브뷰 추가
     private func configureView() {
         //장바구니 헤더에 SubView 추가
@@ -53,17 +55,28 @@ class CartView: UIStackView {
             addArrangedSubview($0)
         }
     }
+    
     //레이아웃 설정
     private func setConstraints() {
         cartTableView.snp.makeConstraints {
             tableViewHeightConstraint = $0.height.equalTo(0).constraint
         }
     }
-    //테이블 뷰 동적 바인딩
-    func updateTableViewHeight() {
-        cartTableView.layoutIfNeeded()
-        let contentHeight = cartTableView.contentSize.height
-        tableViewHeightConstraint?.update(offset: contentHeight)
+    
+    // contentSize 변화를 감지하여 높이 업데이트
+    private func setupContentSizeObserver() {
+        cartTableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
+    }
+    
+    deinit {
+        cartTableView.removeObserver(self, forKeyPath: "contentSize")
+    }
+    
+    // contentSize 변경 감지 시, 높이 제약 업데이트
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == "contentSize" {
+            tableViewHeightConstraint?.update(offset: cartTableView.contentSize.height)
+        }
     }
 }
 

--- a/KioskProject/Presentation/Sources/View/Cell/CartTableViewCell.swift
+++ b/KioskProject/Presentation/Sources/View/Cell/CartTableViewCell.swift
@@ -63,7 +63,6 @@ class CartTableViewCell: UITableViewCell {
         productNameLabel.text = item.product.title
         orderAmountsLabel.text = item.totalPrice.wonFormatter()
         orderCountLabel.text = "\(item.count)"
-        delegate?.addedCart()
         bindActions()
     }
     
@@ -111,7 +110,6 @@ class CartTableViewCell: UITableViewCell {
     }
 
     // MARK: - Actions
-    
     private func bindActions() {
         incrementButton.rx.tap
             .bind { [weak self] in

--- a/KioskProject/Presentation/Sources/View/Cell/ProductCollectionViewCell.swift
+++ b/KioskProject/Presentation/Sources/View/Cell/ProductCollectionViewCell.swift
@@ -46,6 +46,13 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        productImageView.image = nil
+        productNameLabel.text = nil
+        priceLabel.text = nil
+    }
+    
     override func layoutSubviews() {
         super.layoutSubviews()
         
@@ -54,11 +61,13 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         self.layer.cornerRadius = 8
         self.clipsToBounds = true
     }
-    public func configure(product:Product){
+    
+    public func configure(product: Product) {
         productImageView.kf.setImage(with: URL(string: product.thumbnail))
         productNameLabel.text = product.title
         priceLabel.text = product.price.wonFormatter()
     }
+    
     private func configureView() {
         contentView.addSubview(containerView)
         [productImageView, productNameLabel, priceLabel].forEach {
@@ -67,7 +76,6 @@ final class ProductCollectionViewCell: UICollectionViewCell {
     }
 
     private func setupConstraints() {
-        
         containerView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -75,7 +83,7 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         productImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
-//            $0.height.equalTo(productImageView.snp.width)
+            $0.height.equalTo(productImageView.snp.width).multipliedBy(0.6)
         }
         
         productNameLabel.snp.makeConstraints {
@@ -85,8 +93,8 @@ final class ProductCollectionViewCell: UICollectionViewCell {
         
         priceLabel.snp.makeConstraints {
             $0.top.equalTo(productNameLabel.snp.bottom).offset(8)
-            $0.leading.equalTo(productNameLabel.snp.leading)
-            $0.bottom.equalToSuperview().offset(-8)
+            $0.horizontalEdges.equalToSuperview().inset(8)
+//            $0.bottom.equalToSuperview().offset(-8)
         }
     }
     

--- a/KioskProject/Presentation/Sources/View/MainView.swift
+++ b/KioskProject/Presentation/Sources/View/MainView.swift
@@ -13,32 +13,32 @@ import Then
 
 final class MainView: UIView {
     
-    
     // 스크롤뷰 안에 잡혀질 컨텐트 뷰
     let mainContentView = UIView()
-    //TJ 미디어 타이틀 뷰
+    // TJ 미디어 타이틀 뷰
     let titleView = TitleView()
-    //메뉴 카테고리 뷰
+    // 메뉴 카테고리 뷰
     let categoryView = CategoryView(frame: .zero)
-    //메뉴 컬렉션 뷰
+    // 메뉴 컬렉션 뷰
     let productCollectionView = ProductCollectionView()
-    //장바구니 뷰
+    // 장바구니 뷰
     let cartView = CartView()
-    //최종금액 뷰
+    // 최종금액 뷰
     let paymentView = PaymentView()
-    //주문/취소 버튼 뷰
+    // 주문/취소 버튼 뷰
     let orderButtonView = OrderButtonView()
-    
+    // 구분선 뷰
     let dividerView = UIView().then {
         $0.backgroundColor = .gray
     }
     
-    //스크롤뷰
+    // 스크롤뷰
     let mainScrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
         $0.showsHorizontalScrollIndicator = false
     }
-    //페이지먼트컨트롤
+    
+    // 페이지컨트롤
     let pageControl = UIPageControl().then {
         $0.currentPage = 0
         $0.currentPageIndicatorTintColor = .black
@@ -55,9 +55,9 @@ final class MainView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
     //view 추가
     private func configureView() {
-        
         [mainScrollView, dividerView, orderButtonView].forEach {
             addSubview($0)
         }
@@ -70,11 +70,12 @@ final class MainView: UIView {
             mainContentView.addSubview($0)
         }
     }
+    
     //레이아웃 설정
     private func setConstraints() {
         let spacing: CGFloat = 16
         let totalSpacing = spacing * 3
-        let width = (UIScreen.main.bounds.width - spacing * 3) / 2
+        let width = (UIScreen.main.bounds.width - totalSpacing) / 2
         let height = width * 2 + totalSpacing
         
         mainScrollView.snp.makeConstraints {
@@ -123,11 +124,13 @@ final class MainView: UIView {
             $0.trailing.equalToSuperview().offset(-16)
             $0.bottom.equalToSuperview().offset(-16)
         }
+        
         dividerView.snp.makeConstraints {
             $0.height.equalTo(0.5)
             $0.top.equalTo(orderButtonView)
             $0.horizontalEdges.equalToSuperview()
         }
+        
         orderButtonView.snp.makeConstraints {
             $0.bottom.equalTo(safeAreaLayoutGuide).offset(-8)
             $0.leading.equalTo(safeAreaLayoutGuide)

--- a/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
+++ b/KioskProject/Presentation/Sources/View/ProductCollectionView.swift
@@ -30,9 +30,9 @@ final class ProductCollectionView: UICollectionView {
             let width = (bounds.width - totalSpacing) / 2
             let height = width
             
-            // productNameLabel height: 25
-            // priceLabel hegith: 22
-//            let height = width + 47 + (8 * 3)
+            // productNameLabel height: 25.33
+            // priceLabel hegith: 21.67
+//            let height = (width * 0.6) + 47 + (8 * 3)
             
             layout.itemSize = CGSize(width: width, height: height)
             layout.minimumLineSpacing = spacing

--- a/KioskProject/Presentation/Sources/ViewController/Delegate/CartCellDelegate.swift
+++ b/KioskProject/Presentation/Sources/ViewController/Delegate/CartCellDelegate.swift
@@ -12,5 +12,4 @@ protocol CartCellDelegate:AnyObject{
     func removeFormCart(product:Product)
     func didTapIncrease(cell: CartTableViewCell)
     func didTapDecrease(cell: CartTableViewCell)
-    func addedCart()
 }

--- a/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
+++ b/KioskProject/Presentation/Sources/ViewController/MainViewController.swift
@@ -120,7 +120,13 @@ final class MainViewController: UIViewController {
         output.showAlert
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] type in
-                self?.showAlert(type: type)
+                self?.showAlert(type: type) {
+                    switch type{
+                    case .confirmCancel,.confirmOrder(_):
+                        self?.viewModel.removeAllCart()
+                    case .emptyCart: return
+                    }
+                }
             })
             .disposed(by: disposeBag)
         
@@ -139,8 +145,9 @@ final class MainViewController: UIViewController {
                     CartSection(model: "amount", items: [amountItem])
                 ]
             }
-            .bind(to: mainView.cartView.cartTableView.rx.items(dataSource: dataSources))
+            .bind(to:  mainView.cartView.cartTableView.rx.items(dataSource: dataSources))
             .disposed(by: disposeBag)
+        
     }
 }
 

--- a/KioskProject/Presentation/Sources/ViewModel/MainViewModel.swift
+++ b/KioskProject/Presentation/Sources/ViewModel/MainViewModel.swift
@@ -29,8 +29,9 @@ final class MainViewModel: ViewModel {
         let setTotalNum:BehaviorRelay<Int>                      //총 개수 output
         let showAlert: Observable<AlertType>                    //Alert
     }
+    
     // Cell 이벤트 Relay로 ViewModel에 명령 전달 - (수량 증가/감소, 삭제 이벤트)
-    struct CellInput{
+    struct CellInput {
         let increaseRelay = PublishRelay<Int>()
         let decreaseRelay = PublishRelay<Int>()
         let removeRelay = PublishRelay<Product>()
@@ -75,6 +76,7 @@ final class MainViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     //장바구니 추가
     private func addToCart(input:Input) {
         input.selectedCell
@@ -95,6 +97,7 @@ final class MainViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     //상품 수량 증가
     private func increaseCellNum(input:Input) {
         input.increaseTapped
@@ -110,6 +113,7 @@ final class MainViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     //상품 수량 감소
     private func decreaseCellNum(input:Input) {
         input.decreaseTapped
@@ -128,6 +132,7 @@ final class MainViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     //상품 삭제
     private func removeCell(input:Input) {
         input.removeTapped
@@ -140,6 +145,7 @@ final class MainViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     //alert 이벤트 호출
     private func alertEvent(input:Input){
         let orderCancel = input.orderCancelTapped.map { AlertType.confirmCancel }
@@ -151,16 +157,19 @@ final class MainViewModel: ViewModel {
             .bind(to: showAlert)
             .disposed(by: disposeBag)
     }
+    
     //총 개수 계산
     private func calculateTotalCount(items:[CartItem]) {
         let total = items.reduce(0) { $0 + $1.count }
         self.totalNum.accept(total)
     }
+    
     //총 금액 계산
     private func calculateTotalAmount(items:[CartItem]){
         let total = items.reduce(0) { $0 + $1.totalPrice }
         self.totalAmount.accept(total)
     }
+    
     //Intput -> Output 스트림
     func transform(input: Input) -> Output {
         

--- a/KioskProject/Presentation/Sources/ViewModel/MainViewModel.swift
+++ b/KioskProject/Presentation/Sources/ViewModel/MainViewModel.swift
@@ -157,6 +157,11 @@ final class MainViewModel: ViewModel {
             .bind(to: showAlert)
             .disposed(by: disposeBag)
     }
+    func removeAllCart(){
+        totalNum.accept(0)
+        totalAmount.accept(0)
+        cartItems.accept([])
+    }
     
     //총 개수 계산
     private func calculateTotalCount(items:[CartItem]) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 장바구니 tableView의 높이를 cell의 개수에 맞게 동적으로 지정될 수 있도록 수정
- 주문취소, 주문하기 이벤트 추가
<!---- Resolves: #(Isuue Number) -->

# What is this PR? 🔍
- Issues: https://github.com/Team-TJ-Media/KioskProject/issues/24

## PR 유형 ☑️
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## Changes 📝
상세한 변경 사항을 적어주세요!

- 장바구니 tableView의 높이를 cell의 개수에 맞게 동적으로 지정될 수 있도록 수정
- 장바구니에 상품이 존재할 때 주문취소 -> 확인 클릭 시 장바구니 및 최종금액 초기화
- 장바구니에 상품이 존재할 때 주문하기 -> 확인 클릭 시 장바구니 및 최종금액 초기화

## ScreenShot 📸
| 기능 | 이전 스크린샷 | 이후 스크린샷 |
|-------|-------|-------|
| **Cell의 개수에 따른 장바구니 TableView 동적 height** | - | ![SimulatorScreenRecording-iPhone16Pro-2025-04-10at22 40 42-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c55eb4fc-8ffd-4097-8b4a-ec5123ec3258) |
| **장바구니에 상품이 존재할 때 주문 취소** | - | ![SimulatorScreenRecording-iPhone16Pro-2025-04-10at22 41 09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b0db70ee-3a1f-49a0-96a2-b87457468b8a) |
| **장바구니에 상품이 존재할 때 주문 확인** | - | ![SimulatorScreenRecording-iPhone16Pro-2025-04-10at22 41 28-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c30e9f9a-2eea-464a-a8e6-0d7ab1b42269) |
| 링크 | [📎]() | [📎]() |

## Test Checklist ✅
- [x] 장바구니에 상품이 존재하지 않을 때 상품이 존재할 때에 맞게 tableView의 높이가 동적으로 업데이트 됩니다.
- [x] 장바구니에 상품이 존재할 때 주문 취소 시 장바구니와 최종금액이 모두 초기화됩니다.
- [x] 장바구니에 상품이 존재할 때 주문 확인 시 장바구니와 최종금액이 모두 초기화됩니다.

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. (커밋 메시지 컨벤션 참고)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
